### PR TITLE
Issue #52: Local server default to HTTPS

### DIFF
--- a/templates/.env.development
+++ b/templates/.env.development
@@ -1,1 +1,2 @@
 GEN_DOC=true
+HTTPS = true


### PR DESCRIPTION
Adding HTTPS by default to the local development server. This issue is based on the ticket #52 