### PR TITLE
Issue #108: Add 'isAndroid' to util 'detect' + more

### DIFF
--- a/templates/src/util/detect.js
+++ b/templates/src/util/detect.js
@@ -1,8 +1,6 @@
 import bowser from 'bowser';
-import MobileDetect from 'mobile-detect';
 
 const ua = window.navigator.userAgent.toLowerCase();
-const md = new MobileDetect(ua);
 const bots = [
   'facebookexternalhit',
   'linkedinbot',
@@ -14,7 +12,6 @@ const bots = [
   'googlebot'
 ];
 
-// const checkBot = () => Boolean(bots.filter(bot => ua.includes(bot.toLowerCase())).length);
 const checkBot = () => Boolean(bots.filter(bot => ua.indexOf(bot.toLowerCase()) !== -1).length);
 const checkVendor = () => (window.navigator.vendor ? window.navigator.vendor.toLowerCase() : '');
 const checkOSVersion = () => bowser.osversion;
@@ -220,8 +217,7 @@ const detect = {
   device,
   devicePixelRatio,
   // Libraries
-  bowser,
-  md
+  bowser
 };
 
 // Named exports
@@ -280,8 +276,7 @@ export {
   device,
   devicePixelRatio,
   // Libraries
-  bowser,
-  md
+  bowser
 };
 
 // Default export


### PR DESCRIPTION
## Problem
1. **Fixes #108 :** The component `Rotate` uses `isAndroid` from `detect` to see which event it should listen too. But always ends up in `resize` cause `isAndroid` is `undefined`.
2. `os`s are not as `flags` but only as a string in the property `os`, so one has to know what `bowser` returns per each `os`.
3. `osVersion` and `browserVersion` are as strings + there is no `majorVersion` for each one for making simple comparisons.
4. `window.screen.msOrientation` is the `type` itself, not the `object` [ref](https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation)
5. No **"named exports"** so one always has to import the whole **util** + this doesn't help "tree shaking"
6. `toLocaleLowerCase` is used which makes things (that should be "static") the chance of being "dynamic" (for example: `browser.name`).
7. Uses `indexOf` instead of `/regex/.test()` for `boolean` returns.

## Solution
1. Added the property `isAndroid` to `detect`.
2. Added `os`s as flags.
3. Left **string** version of each, but added a `majorVersion` for each one of type **number**.
4. Changed how `screen.orientation.type` is being extracted.
5. Added all properties (except **getters**) as **"named exports"** as well.
6. Changed `toLocaleLowerCase` for `toLowerCase`.
7. Changed `indexOf` for `/regex/.test()`, its supposed to be faster [ref](https://koukia.ca/top-6-ways-to-search-for-a-string-in-javascript-and-performance-benchmarks-ce3e9b81ad31)

## Comments
1. Added `window.matchMedia` as an option for `orientation` before getting to the `width/height` solution.
2. Added in `checkInAppBrowser` a solution I had for another project, cause `checkTwitter` didn't work for me, there was no `twitter` in the `userAgent` (left if for "compatibility reasons").
3. Added `PORTRAIT` and `LANDSCAPE` as **"named exports"** so one knows what to compare  `orientation` too.
4. Added the `os` to the `classes` property too.

## Questions
1. Should we remove `mobile-detect`? What is the main difference with `bowser`? The **util** just exports it.
