### PR TITLE
Update gsap-promisify to 1.0.2

### DIFF
--- a/templates/package.json
+++ b/templates/package.json
@@ -48,7 +48,7 @@
     "classnames": "2.2.5",
     "fullscreen-handler": "0.0.2",
     "gsap": "1.20.4",
-    "gsap-promisify": "1.0.1",
+    "gsap-promisify": "1.0.2",
     "history": "4.7.2",
     "howler": "2.0.9",
     "include-media": "1.4.9",


### PR DESCRIPTION
Remove `nsp` from `gsap-promisify`.

Now that npm bought it, they decided removing it :-(

https://github.com/iranreyes/gsap-promisify/releases/tag/v1.0.2
https://github.com/iranreyes/gsap-promisify/commit/faa0e45198f6cbb1b0943581e7c68caa71e94943