### PR TITLE
Fix unit tests escaping

### DIFF
--- a/templates/src/util/test/sanitizer.test.js
+++ b/templates/src/util/test/sanitizer.test.js
@@ -21,8 +21,10 @@ describe('Sanitizer: Malicious attributes', () => {
   });
 
   test('iframe src attribute', () => {
+    /* eslint-disable */
     // prettier-ignore
     expect(sanitizer('<p>abc<iframe/\/src=jAva&Tab;script:alert(3)>def')).toBe('<p>abcdef</p>');
+    /* eslint-enable */
   });
 
   test('math xlink attribute', () => {


### PR DESCRIPTION
The linter is complaining about the escaping in the XSS tests