### PR TITLE
Issue #170 Make prettier throw a warning instead of an error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,7 @@
   "plugins": ["prettier"],
   "extends": ["eslint:recommended", "prettier"],
   "rules": {
-    "prettier/prettier": "error",
+    "prettier/prettier": "warn",
     "no-console": "off",
     "no-unused-vars": "warn",
     "require-jsdoc": [

--- a/templates/.eslintrc
+++ b/templates/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["react-app", "jam3"],
   "plugins": ["jam3"],
   "rules": {
+    "prettier/prettier": "warn",
     "jam3/no-sanitizer-with-danger": [
       2,
       {


### PR DESCRIPTION
Issue #170 It stops preventing the user from compiling if there are prettier errors.