### PR TITLE
Fix #157: Isolate helper properties in layout.js

### DIFF
--- a/templates/src/style/vars.scss
+++ b/templates/src/style/vars.scss
@@ -10,9 +10,9 @@
 // Window breakpoints
 // ====================================================================
 
-$layout-medium: map-get($layout, medium) + px;
-$layout-large: map-get($layout, large) + px;
-$layout-xlarge: map-get($layout, xlarge) + px;
+$layout-medium: map-get($layout, medium) * 1px;
+$layout-large: map-get($layout, large) * 1px;
+$layout-xlarge: map-get($layout, xlarge) * 1px;
 
 // ====================================================================
 // Animation

--- a/templates/src/util/layout.js
+++ b/templates/src/util/layout.js
@@ -7,14 +7,18 @@ const MEDIUM_MATCH_MEDIA = window.matchMedia(MEDIUM_MEDIA_QUERY);
 const LARGE_MATCH_MEDIA = window.matchMedia(LARGE_MEDIA_QUERY);
 
 export default {
-  get small() {
-    return !this.medium;
-  },
   get medium() {
     return MEDIUM_MATCH_MEDIA.matches;
   },
   get large() {
     return LARGE_MATCH_MEDIA.matches;
+  },
+  // The next two are kind of anti-pattern but useful helpers.
+  get small() {
+    return !this.medium;
+  },
+  get mediumOnly() {
+    return this.medium && !this.large;
   },
   get all() {
     return {


### PR DESCRIPTION
## Purpose

Heard people saying it's a bit confusing b/c we're trying to align with what we do in the css world. I figured adding the helper ones like `mediumOnly` would help better understanding it. (like I mentioned in #157)

And if someone still couldn't understand, I'm more than happy to explain why. Same goes for using `* 1px` instead of appending `px` to add the unit – I could explain more in person why that's the case.