### PR TITLE
Modify pages css and transitions

### DIFF
--- a/templates/src/components/Footer/Footer.scss
+++ b/templates/src/components/Footer/Footer.scss
@@ -1,9 +1,7 @@
 @import 'shared.scss';
 
 .Footer {
-  position: absolute;
-  bottom: 0;
-  left: 0;
+  position: relative;
   @include flex-center-vert;
   justify-content: space-between;
   flex-direction: column;

--- a/templates/src/components/Pages/Pages.scss
+++ b/templates/src/components/Pages/Pages.scss
@@ -3,16 +3,15 @@
 .Pages {
   position: relative;
   text-align: center;
-  margin-top: $navbar-height-mobile;
+  padding-top: $navbar-height-mobile;
+  min-height: 100vh;
 
   @media (min-width: $layout-large) {
-    margin-top: $navbar-height-desktop;
+    // margin-top: $navbar-height-desktop;
   }
 
   & > section {
-    position: absolute;
-    top: 0;
-    left: 0;
+    position: relative;
     width: 100%;
   }
 }

--- a/templates/src/pages/About/About.js
+++ b/templates/src/pages/About/About.js
@@ -19,7 +19,7 @@ class About extends React.PureComponent {
   }
 
   componentDidMount() {
-    animate.set(this.container, { autoAlpha: 0 });
+    animate.set(this.container, { autoAlpha: 0, display: 'none' });
   }
 
   onAppear = () => {
@@ -36,7 +36,7 @@ class About extends React.PureComponent {
   };
 
   animateIn = () => {
-    animate.to(this.container, 0.3, { autoAlpha: 1 });
+    animate.to(this.container, 0.3, { autoAlpha: 1, display: 'block' });
   };
 
   animateOut = () => {

--- a/templates/src/pages/About/About.scss
+++ b/templates/src/pages/About/About.scss
@@ -1,5 +1,8 @@
 @import 'shared.scss';
 
 .About {
-
+  padding-top: 2.5rem;
+  h1 {
+    margin-top: 0;
+  }
 }

--- a/templates/src/pages/Landing/Landing.js
+++ b/templates/src/pages/Landing/Landing.js
@@ -22,7 +22,7 @@ class Landing extends React.PureComponent {
   }
 
   componentDidMount() {
-    animate.set(this.container, { autoAlpha: 0 });
+    animate.set(this.container, { autoAlpha: 0, display: 'none' });
 
     if (!this.props.loaded) {
       // await for data to be loaded here e.g. via fetch
@@ -44,7 +44,7 @@ class Landing extends React.PureComponent {
   };
 
   animateIn = () => {
-    animate.to(this.container, 0.3, { autoAlpha: 1 });
+    animate.to(this.container, 0.3, { autoAlpha: 1, display: 'block' });
   };
 
   animateOut = () => {

--- a/templates/src/pages/PagesTransitionWrapper.js
+++ b/templates/src/pages/PagesTransitionWrapper.js
@@ -20,6 +20,7 @@ const PagesTransitionWrapper = Class => {
   const componentDidMount = Class.prototype.componentDidMount;
   Class.prototype.componentDidMount = function() {
     componentDidMount && componentDidMount.call(this);
+
     if (
       this.props.transitionState === transitionStates.entered ||
       this.props.transitionState === transitionStates.entering
@@ -36,6 +37,15 @@ const PagesTransitionWrapper = Class => {
     } else if (this.props.transitionState === transitionStates.exiting) {
       handleLeaveTransition(this.onLeave);
     }
+  };
+
+  const componentWillUnmount = Class.prototype.componentWillUnmount;
+  Class.prototype.componentWillUnmount = function() {
+    componentWillUnmount && componentWillUnmount.apply(this, arguments);
+
+    // Scroll to the top of document on page unmount
+    document.body.scrollTop = 0; // For Safari
+    document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
   };
 
   return Class;


### PR DESCRIPTION
Made page and footer components relatively positioned, and made pages min height 100vh. This introduced a new issue where pages would stack when switching between then. Applied a quick fix of display:none on componentDidMount and display:block on animateIn. 

Also added a scroll to top on componentWillUnmount for page components to ensure user starts the new page at the top.