### PR TITLE
Fix gitignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const generator = nyg(null, globs)
  */
 function onPostInstall() {
   var done = generator.async();
-  Promise.all([updateNvmVersion(), updateGeneratedPackageJson()])
+  Promise.all([updateNvmVersion(), updateGeneratedPackageJson(), renameGitIgnore()])
     .then(() => {
       console.log('App generated');
       done();
@@ -55,6 +55,22 @@ function updateGeneratedPackageJson() {
 
   return _updateNodeJSRequiredVersion(packagePath, generatedPackageJson).then(() => {
     _updateLintStaged(packagePath, generatedPackageJson);
+  });
+}
+
+/**
+ * Rename gitignore to .gitignore
+ *
+ */
+function renameGitIgnore() {
+  const gitIgnorePath = `${generator.cwd}/gitignore`;
+  const generatedGitIgnore = `${generator.cwd}/.gitignore`;
+
+  return new Promise((resolve, reject) => {
+    fs.rename(gitIgnorePath, generatedGitIgnore, function(err) {
+      if (err) return reject();
+      resolve();
+    });
   });
 }
 

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -1,0 +1,44 @@
+## -------- Welcome to the Jam3 Generator gitignore --------
+##
+## Please add your generator ignores ordered by topics.
+## See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# Global
+.DS_Store
+*.log*
+
+# IDEs
+.vscode
+sketch
+
+# Node & Npm
+node_modules
+
+# Builds
+/build
+
+# Stats
+stats.html
+
+# Testing
+/coverage
+
+# Create React App Dev
+default-cra-rewrite-config.json
+final-cra-rewrite-config.json
+bundle-size-analyzer.html
+bundle-analyzer-report.html
+
+# CSS files of src
+src/**/*.css
+
+# Dynamically built files
+src/style/layout.scss
+
+# Local env variables
+.env.local
+.env.*.local
+
+# Documentation
+public/components
+public/styleguide


### PR DESCRIPTION
Adding `gitignore` file and renaming it on the post install script.

Issues:
Now we have `.gitignore` and `gitignore`, we have to change both if we make changes, or we could remove .gitignore but if someone copy and paste the templates folder to create a new project they would need to manually rename it