### PR TITLE
Fix gsap util staggerTo

### DIFF
--- a/templates/src/util/gsap-animate.js
+++ b/templates/src/util/gsap-animate.js
@@ -16,7 +16,7 @@ animate.staggerTo = function(els, duration, props, delay) {
     els.map((el, i) =>
       animate.to(el, duration, {
         ...props,
-        delay: props.delay + delay * i
+        delay: (props.delay || 0) + delay * i
       })
     )
   );


### PR DESCRIPTION
## Problem
`staggerTo` did not work properly as they should be when missing `delay` property. It returns `NaN`.
