### PR TITLE
Fix stylelint error

### DIFF
--- a/templates/package.json
+++ b/templates/package.json
@@ -108,7 +108,7 @@
     "react-scripts": "2.1.3",
     "snyk": "1.82.0",
     "storybook-addon-jsx": "6.0.0",
-    "stylelint": "9.9.0",
+    "stylelint": "9.10.0",
     "stylelint-config-jam3": "0.1.2",
     "webpack-bundle-analyzer": "3.0.3"
   },


### PR DESCRIPTION
## ISSUE
`npm run sass-lint` will fail on a certain local environment setup. I cannot tell which cases. But, it has appeared to me quite a lot.
```
TypeError: Expected `cwd` to be of type `string` but received type `undefined` 
```

## SOLUTION
Upgrade `stylelint` version to 9.10.0 from 9.9.0. `globby` version 8.0.1 cause the issue, and `stylelint` bumpped up `globby` version to 9.0.0 which fixes this problem.
Reference : https://github.com/stylelint/stylelint/pull/3890