### PR TITLE
Add staggerFrom and staggerFromTo to gsap util file

### DIFF
--- a/templates/src/util/gsap-animate.js
+++ b/templates/src/util/gsap-animate.js
@@ -9,16 +9,43 @@ import { TweenLite, CSSPlugin } from 'gsap';
 
 const animate = require('gsap-promisify')(Promise, TweenLite);
 
-animate.staggerTo = function(els, duration, props, delay) {
+animate.staggerTo = function (els, duration, props, staggerDelay) {
   return Promise.all(
     els.map((el, i) =>
       animate.to(el, duration, {
         ...props,
-        delay: (props.delay || 0) + delay * i
+        delay: (props.delay || 0) + staggerDelay * i
       })
     )
   );
 };
+
+// animate.staggerFrom = function (els, duration, props, staggerDelay) {
+//   return Promise.all(
+//     els.map((el, i) =>
+//       animate.from(el, duration, {
+//         ...props,
+//         delay: (props.delay || 0) + staggerDelay * i
+//       })
+//     )
+//   );
+// };
+
+// animate.staggerFromTo = function (els, duration, initialProps, finalProps, staggerDelay) {
+//   return Promise.all(
+//     els.map((el, i) =>
+//       animate.fromTo(
+//         el,
+//         duration,
+//         { ...initialProps },
+//         {
+//           ...finalProps,
+//           delay: (finalProps.delay || 0) + staggerDelay * i
+//         }
+//       )
+//     )
+//   );
+// };
 
 export const GSAP_PLUGINS = { CSSPlugin };
 export default animate;


### PR DESCRIPTION
Might be useful to have the methods for `staggerFrom` and `staggerFromTo` commented out in case we need it for some projects since I find myself adding this for some projects, also we could:
1.  Comment out `staggerTo` too and every method will be on-demand if devs need it they will uncomment
2. Have all 3 methods exposed