### PR TITLE
Fix lazy import issue for NotFound component

### DIFF
--- a/templates/src/components/Pages/Pages.js
+++ b/templates/src/components/Pages/Pages.js
@@ -12,7 +12,7 @@ import { getTransitionDuration } from '../../data/pages-transitions';
 
 const Landing = lazy(() => import('../../pages/Landing/Landing'));
 const About = lazy(() => import('../../pages/About/About'));
-const NotFound = lazy(() => import('../../pages/NotFound/NotFound')).default;
+const NotFound = lazy(() => import('../../pages/NotFound/NotFound'));
 
 const Pages = ({ location, ...props }) => {
   return (


### PR DESCRIPTION
**Test plan**

Ran `npm start` locally and went to http://localhost:[port]/something-non-existant and successfully rendered the following:
<img width="1440" alt="screen shot 2019-02-28 at 3 19 58 pm" src="https://user-images.githubusercontent.com/13773039/53595865-62b44980-3b6c-11e9-8551-2c86276427d6.png">



