### PR TITLE
docs: add templates for issues and pr for the generator and template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[Bug] TODO_CHANGE_BUG_TITLE'
+labels: bug
+assignees: iranreyes
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is  -->
+
+## To Reproduce
+
+<!--
+If the issue is not reproducible, it can't be fixed
+
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+ -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Environment
+
+Run the below command and paste the result here:
+
+```
+npx envinfo --system --npmPackages react* --binaries --npmGlobalPackages react* --browsers
+```
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[Feature] TODO_CHANGE_FEATURE_TITLE '
+labels: ''
+assignees: iranreyes
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**What does the proposed API look like?**
+What kind of methods it will have, how do you think you will use it?
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
+-->
+
+<!--- Provide a general summary of your changes in the PR Title -->
+
+**What kind of change does this PR introduce?** (check at least one)
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Feature (non-breaking change which adds functionality)
+- [ ] Code style update
+- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Build-related changes
+- [ ] Other, please describe:
+
+**Does this PR introduce a breaking change?** (check one)
+
+- [ ] Yes
+- [ ] No
+
+**Did you test your solution?**
+
+- [ ] I lightly tested it in one browser
+- [ ] I deeply tested it in several browsers
+- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)
+
+## Problem Description
+
+<!--- Describe the problem briefly or reference related issues -->
+
+## Solution Description
+
+<!--- Describe your changes in detail -->
+
+## Side Effects, Risks, Impact
+
+<!--- May your changes break other parts of the application? -->
+
+- [ ] N/A
+
+**Aditional comments:**

--- a/templates/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/templates/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[Bug] TODO_CHANGE_BUG_TITLE'
+labels: bug
+assignees: iranreyes
+---
+
+## Describe the bug
+
+<!-- A clear and concise description of what the bug is  -->
+
+## To Reproduce
+
+<!--
+If the issue is not reproducible, it can't be fixed
+
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+ -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Environment
+
+Run the below command and paste the result here:
+
+```
+npx envinfo --system --npmPackages react* --binaries --npmGlobalPackages react* --browsers
+```
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/templates/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/templates/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[Feature] TODO_CHANGE_FEATURE_TITLE '
+labels: ''
+assignees: iranreyes
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**What does the proposed API look like?**
+What kind of methods it will have, how do you think you will use it?
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/templates/.github/PULL_REQUEST_TEMPLATE.md
+++ b/templates/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+<!--
+Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
+-->
+
+<!--- Provide a general summary of your changes in the PR Title -->
+
+**What kind of change does this PR introduce?** (check at least one)
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] Feature (non-breaking change which adds functionality)
+- [ ] Code style update
+- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Build-related changes
+- [ ] Other, please describe:
+
+**Does this PR introduce a breaking change?** (check one)
+
+- [ ] Yes
+- [ ] No
+
+**Did you test your solution?**
+
+- [ ] I lightly tested it in one browser
+- [ ] I deeply tested it in several browsers
+- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)
+
+## Problem Description
+
+<!--- Describe the problem briefly or reference related issues -->
+
+## Solution Description
+
+<!--- Describe your changes in detail -->
+
+## Side Effects, Risks, Impact
+
+<!--- May your changes break other parts of the application? -->
+
+- [ ] N/A
+
+**Aditional comments:**

--- a/templates/docs/PULL_REQUEST_TEMPLATE.md
+++ b/templates/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-## Solution
-
-## Side Effects or Risks
-
-## Comments


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/Jam3/.github/CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [x] Other, please describe: Docs

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [ ] I lightly tested it in one browser
- [x] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Github templates are too ambiguous 

## Solution Description

Improve the template for the PRs and add templates for issues

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [x] N/A

**Aditional comments:**
