### PR TITLE
Fix page scaffolding path

### DIFF
--- a/templates/scripts/component.js
+++ b/templates/scripts/component.js
@@ -56,8 +56,8 @@ function write() {
     const files =
       type === 'page'
         ? [
-            template(path.resolve(__dirname, 'templates/Page/Page.js'), path.resolve(dir, `${name}.js`)),
-            template(path.resolve(__dirname, 'templates/Page/Page.scss'), path.resolve(dir, `${name}.scss`))
+            template(path.resolve(__dirname, 'templates/page/Page.js'), path.resolve(dir, `${name}.js`)),
+            template(path.resolve(__dirname, 'templates/page/Page.scss'), path.resolve(dir, `${name}.scss`))
           ]
         : [
             template(path.resolve(__dirname, 'templates/' + type + '/Component.js'), path.resolve(dir, `${name}.js`)),


### PR DESCRIPTION
The 'page' folder must be in lowercase, so it is in the files.

<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

The 'page' folder must be in lowercase, so it is in the files.

## Solution Description

I have changed the path from uppercase to lowercase as in the real path

## Side Effects, Risks, Impact

- [x] N/A

**Aditional comments:**
